### PR TITLE
Standardize API routes and add env template

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,6 @@
+# Example environment configuration for ViralSynth
+APIFY_API_TOKEN=your-apify-token
+SUPABASE_URL=your-supabase-url
+SUPABASE_ANON_KEY=your-supabase-anon-key
+OPENAI_API_KEY=your-openai-api-key
+DALL_E_API_KEY=your-dall-e-api-key

--- a/README.md
+++ b/README.md
@@ -32,9 +32,9 @@ Supporting agent specifications (`agents.md`, `agents_architect.md`, `agents_spe
 
 | Method | Endpoint        | Description                          |
 |-------|-----------------|--------------------------------------|
-| POST  | `/ingest/`      | Ingest trending content data for analysis. |
-| POST  | `/strategy/`    | Analyze patterns and strategies from ingested data. |
-| POST  | `/generate/`    | Generate a full content package (script, storyboard, notes) based on a prompt. |
+| POST  | `/api/ingest`      | Ingest trending content data for analysis. |
+| POST  | `/api/strategy`    | Analyze patterns and strategies from ingested data. |
+| POST  | `/api/generate`    | Generate a full content package (script, storyboard, notes, variations) based on a prompt. |
 
 These endpoints currently return placeholder responses and should be extended with logic to call scraping services, transcription models and generative models.
 
@@ -55,7 +55,11 @@ These endpoints currently return placeholder responses and should be extended wi
 
    The dashboard will be available at `http://localhost:3000`.
 
-The frontend fetches data from the backend’s `/generate` endpoint, displays the generated script and production notes, and renders image storyboards. Tailwind CSS is configured in `tailwind.config.js` and global styles are defined in `styles/globals.css`.
+The frontend fetches data from the backend’s `/api/generate` endpoint, displays the generated script and production notes, and renders image storyboards. Tailwind CSS is configured in `tailwind.config.js` and global styles are defined in `styles/globals.css`.
+
+### Environment Variables
+
+Copy `.env.example` to `.env` and populate it with API keys for Apify, Supabase, and AI providers before running locally or deploying.
 
 ## Deployment
 

--- a/backend/main.py
+++ b/backend/main.py
@@ -1,3 +1,5 @@
+"""Entry point for the ViralSynth FastAPI application."""
+
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 

--- a/backend/models.py
+++ b/backend/models.py
@@ -1,5 +1,7 @@
+"""Pydantic data models used across the ViralSynth backend."""
+
 from pydantic import BaseModel, Field
-from typing import List, Optional
+from typing import Dict, List, Optional
 
 
 class IngestRequest(BaseModel):
@@ -9,6 +11,7 @@ class IngestRequest(BaseModel):
 
 
 class IngestResponse(BaseModel):
+    """Response confirming that an ingest request was received."""
     message: str
 
 
@@ -33,3 +36,7 @@ class GenerateResponse(BaseModel):
     script: str
     storyboard: List[str]
     notes: List[str]
+    variations: Dict[str, str] = Field(
+        default_factory=dict,
+        description="Platform-specific hook and CTA variations",
+    )

--- a/backend/routers/generate.py
+++ b/backend/routers/generate.py
@@ -1,10 +1,11 @@
-from fastapi import APIRouter
+"""Endpoint for generating multi-modal content packages."""
+
 from fastapi import APIRouter
 
 from ..models import GenerateRequest, GenerateResponse
 
 router = APIRouter(
-    prefix="/generate",
+    prefix="/api/generate",
     tags=["generate"],
 )
 
@@ -32,5 +33,14 @@ async def generate_content(request: GenerateRequest) -> GenerateResponse:
         "Maintain an average shot length of 1.2 seconds",
         "Film the A-roll with a blurred background",
     ]
+    variations = {
+        "tiktok": "Hook optimized for TikTok with quick CTA",
+        "instagram": "Reels variation focusing on visual polish",
+    }
 
-    return GenerateResponse(script=script, storyboard=storyboard, notes=notes)
+    return GenerateResponse(
+        script=script,
+        storyboard=storyboard,
+        notes=notes,
+        variations=variations,
+    )

--- a/backend/routers/ingest.py
+++ b/backend/routers/ingest.py
@@ -1,10 +1,11 @@
-from fastapi import APIRouter, HTTPException
-from typing import List
+"""Endpoints for ingesting trending content into ViralSynth."""
+
+from fastapi import APIRouter
 
 from ..models import IngestRequest, IngestResponse
 
 router = APIRouter(
-    prefix="/ingest",
+    prefix="/api/ingest",
     tags=["ingest"],
 )
 

--- a/backend/routers/strategy.py
+++ b/backend/routers/strategy.py
@@ -1,10 +1,11 @@
+"""Endpoints that expose content strategy insights."""
+
 from fastapi import APIRouter
-from typing import List
 
 from ..models import StrategyRequest, StrategyResponse
 
 router = APIRouter(
-    prefix="/strategy",
+    prefix="/api/strategy",
     tags=["strategy"],
 )
 

--- a/frontend/pages/index.tsx
+++ b/frontend/pages/index.tsx
@@ -1,13 +1,21 @@
 import { useState } from 'react';
 
+interface GenerateResponse {
+  script: string;
+  storyboard: string[];
+  notes: string[];
+  variations: Record<string, string>;
+}
+
 export default function Home() {
   const [prompt, setPrompt] = useState('');
-  const [response, setResponse] = useState<any>(null);
+  const [response, setResponse] = useState<GenerateResponse | null>(null);
 
+  // Calls the backend to generate a placeholder content package
   const handleGenerate = async () => {
     if (!prompt) return;
     try {
-      const res = await fetch('http://localhost:8000/generate', {
+      const res = await fetch('http://localhost:8000/api/generate', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ prompt }),
@@ -48,11 +56,23 @@ export default function Home() {
               ))}
             </div>
             <h2 className="text-2xl font-semibold mb-2">Production Notes</h2>
-            <ul className="list-disc list-inside">
+            <ul className="list-disc list-inside mb-4">
               {response.notes && response.notes.map((note: string, idx: number) => (
                 <li key={idx}>{note}</li>
               ))}
             </ul>
+            {response.variations && (
+              <div>
+                <h2 className="text-2xl font-semibold mb-2">Platform Variations</h2>
+                <ul className="list-disc list-inside">
+                  {Object.entries(response.variations).map(([platform, text]) => (
+                    <li key={platform}>
+                      <strong>{platform}:</strong> {text}
+                    </li>
+                  ))}
+                </ul>
+              </div>
+            )}
           </div>
         )}
       </div>

--- a/status.md
+++ b/status.md
@@ -18,6 +18,9 @@ This file tracks the remaining work required to bring the ViralSynth platform to
 10. **Documentation** – Expand `README.md` and `docs/` with setup instructions, API descriptions, architecture diagrams and usage examples.
 11. **Deployment Configuration** – Prepare configuration files for deployment on Vercel (frontend) and Google Cloud Run (backend). Include environment variables and secret management.
 12. **Project Management Updates** – Ensure `status.md` is kept up to date with progress, new tasks and links to issues or pull requests.
+13. **Architecture Documentation** – Produce `docs/architecture.md` outlining system components and interactions.
+14. **API Contract Documentation** – Create `docs/api_contracts.md` detailing request and response schemas for all endpoints.
 
 ## Completed
-- *(No tasks completed yet)*
+- Standardized backend API routes under `/api` and synced frontend calls.
+- Added `.env.example` with required environment variable placeholders.


### PR DESCRIPTION
## Summary
- prefix all backend routes with `/api` and document them
- add platform `variations` field to generation workflow and frontend display
- introduce `.env.example` and update status tracking

## Testing
- `cd backend && python -m pytest`
- `cd .. && cd frontend && npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_68bca5c496dc832b98384be2351644d9