### PR TITLE
feat: add provider routing and groq transcription

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,3 +4,5 @@ SUPABASE_URL=your-supabase-url
 SUPABASE_ANON_KEY=your-supabase-anon-key
 OPENAI_API_KEY=your-openai-api-key
 DALL_E_API_KEY=your-dall-e-api-key
+INGESTION_PROVIDER=apify
+GROQ_API_KEY=your-groq-api-key

--- a/README.md
+++ b/README.md
@@ -57,9 +57,17 @@ These endpoints currently return placeholder responses and should be extended wi
 
 The frontend fetches data from the backend’s `/api/generate` endpoint, displays the generated script and production notes, and renders image storyboards. Tailwind CSS is configured in `tailwind.config.js` and global styles are defined in `styles/globals.css`.
 
+### Ingestion Providers
+
+The ingestion service supports multiple scraping providers. Choose between Apify, Playwright, or Puppeteer by setting the `INGESTION_PROVIDER` environment variable or by sending a `provider` field in requests to `/api/ingest`.
+
+### Transcription Service
+
+Audio is extracted with `ffmpeg` and transcribed via the Groq Whisper API. Set `GROQ_API_KEY` and use the `use_turbo` flag when calling the transcription helper to switch between `whisper-large` and `whisper-turbo` models.
+
 ### Environment Variables
 
-Copy `.env.example` to `.env` and populate it with API keys for Apify, Supabase, and AI providers before running locally or deploying.
+Copy `.env.example` to `.env` and populate it with API keys for Apify, Supabase, AI providers, and transcription services before running locally or deploying.
 
 ## Deployment
 

--- a/backend/models.py
+++ b/backend/models.py
@@ -8,6 +8,10 @@ class IngestRequest(BaseModel):
     """Request model for ingesting trending content data."""
     niches: List[str] = Field(..., description="List of content niches to ingest, e.g., ['tech', 'fitness'].")
     top_percentile: float = Field(0.05, description="Top percentile threshold (0-1) for selecting high performing content.")
+    provider: Optional[str] = Field(
+        None,
+        description="Optional scraping provider: apify, playwright, or puppeteer."
+    )
 
 
 class IngestResponse(BaseModel):

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -3,3 +3,5 @@ uvicorn[standard]==0.23.2
 pydantic==1.10.12
 python-multipart==0.0.7
 httpx==0.26.0
+playwright==1.41.2
+pyppeteer==1.0.2

--- a/backend/routers/ingest.py
+++ b/backend/routers/ingest.py
@@ -3,6 +3,7 @@
 from fastapi import APIRouter
 
 from ..models import IngestRequest, IngestResponse
+from ..services.ingestion import ingest_niche
 
 router = APIRouter(
     prefix="/api/ingest",
@@ -19,7 +20,10 @@ async def ingest_trending_content(request: IngestRequest) -> IngestResponse:
     to collect trending videos, transcribe audio, analyze visual style and pacing, and
     persist the results to a database for further analysis.
     """
-    # TODO: Integrate with Apify or similar service to scrape trending content
-    # and store analysis results in the database.
+    # Call the ingestion service for each niche. The provider can be specified in
+    # the request or via the INGESTION_PROVIDER environment variable.
+    for niche in request.niches:
+        percentile = int(request.top_percentile * 100)
+        await ingest_niche(niche, percentile, provider=request.provider)
 
     return IngestResponse(message="Ingest request received. Ingestion logic not yet implemented.")

--- a/backend/services/transcription.py
+++ b/backend/services/transcription.py
@@ -5,16 +5,14 @@ from typing import Dict, Any
 import httpx
 
 GROQ_API_KEY = os.environ.get("GROQ_API_KEY")
-# Default whisper model: whisper-large or whisper-turbo
-WHISPER_MODEL = os.environ.get("WHISPER_MODEL", "whisper-large")
 
 async def extract_audio_from_video(video_url: str, output_path: str) -> str:
-    """
-    Download the audio track from a video using ffmpeg.
-    Returns the path to the extracted audio file.
+    """Download a video's audio track using ffmpeg.
+
+    Returns the path to the extracted audio file. The ``ffmpeg`` binary must be
+    available on the system path.
     """
     # Use ffmpeg to download audio from the video URL.
-    # ffmpeg must be installed in the running environment.
     process = await asyncio.create_subprocess_exec(
         "ffmpeg", "-i", video_url, "-vn", "-acodec", "mp3", output_path,
         stdout=asyncio.subprocess.PIPE,
@@ -27,12 +25,12 @@ async def extract_audio_from_video(video_url: str, output_path: str) -> str:
     return output_path
 
 async def transcribe_audio(audio_path: str, use_turbo: bool = False) -> Dict[str, Any]:
+    """Transcribe an audio file using Groq's Whisper API.
+
+    If ``use_turbo`` is True, the ``whisper-turbo`` model is used; otherwise the
+    ``whisper-large`` model is selected. Returns the JSON response from the Groq
+    API.
     """
-    Transcribe an audio file using Groq's Whisper API.
-    If use_turbo is True, uses the whisper-turbo model; otherwise whisper-large.
-    Returns the JSON response from the Groq API.
-    """
-    # Determine which model to use
     model = "whisper-turbo" if use_turbo else "whisper-large"
     url = "https://api.groq.com/openai/v1/audio/transcriptions"
     headers = {
@@ -46,3 +44,19 @@ async def transcribe_audio(audio_path: str, use_turbo: bool = False) -> Dict[str
             resp = await client.post(url, headers=headers, data=data, files=files, timeout=60)
             resp.raise_for_status()
             return resp.json()
+
+
+async def transcribe_video(video_url: str, use_turbo: bool = False) -> Dict[str, Any]:
+    """Extract a video's audio with ffmpeg and transcribe it via Groq Whisper.
+
+    This high-level helper downloads the audio track with ``extract_audio_from_video``
+    and then calls ``transcribe_audio``. Temporary audio files are cleaned up after
+    transcription.
+    """
+    audio_path = "temp_audio.mp3"
+    try:
+        await extract_audio_from_video(video_url, audio_path)
+        return await transcribe_audio(audio_path, use_turbo=use_turbo)
+    finally:
+        if os.path.exists(audio_path):
+            os.remove(audio_path)

--- a/frontend/pages/index.tsx
+++ b/frontend/pages/index.tsx
@@ -9,6 +9,9 @@ interface GenerateResponse {
 
 export default function Home() {
   const [prompt, setPrompt] = useState('');
+  const [niche, setNiche] = useState('');
+  const [provider, setProvider] = useState('apify');
+  const [ingestMessage, setIngestMessage] = useState('');
   const [response, setResponse] = useState<GenerateResponse | null>(null);
 
   // Calls the backend to generate a placeholder content package
@@ -27,10 +30,52 @@ export default function Home() {
     }
   };
 
+  // Calls the backend ingestion endpoint with selected provider
+  const handleIngest = async () => {
+    if (!niche) return;
+    try {
+      const res = await fetch('http://localhost:8000/api/ingest', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ niches: [niche], top_percentile: 0.05, provider }),
+      });
+      const data = await res.json();
+      setIngestMessage(data.message);
+    } catch (error) {
+      console.error('Failed to ingest content:', error);
+    }
+  };
+
   return (
     <div className="min-h-screen bg-gray-900 text-white p-4">
       <h1 className="text-3xl font-bold mb-4 text-center">ViralSynth</h1>
       <div className="max-w-2xl mx-auto">
+        <div className="mb-6">
+          <input
+            className="w-full p-3 mb-4 rounded bg-gray-800 border border-gray-700 focus:outline-none focus:ring-2 focus:ring-blue-600"
+            type="text"
+            placeholder="Enter a niche (e.g. tech)..."
+            value={niche}
+            onChange={(e) => setNiche(e.target.value)}
+          />
+          <select
+            className="w-full p-3 mb-4 rounded bg-gray-800 border border-gray-700 focus:outline-none"
+            value={provider}
+            onChange={(e) => setProvider(e.target.value)}
+          >
+            <option value="apify">Apify</option>
+            <option value="playwright">Playwright</option>
+            <option value="puppeteer">Puppeteer</option>
+          </select>
+          <button
+            className="bg-green-600 hover:bg-green-700 text-white py-2 px-4 rounded w-full transition-colors"
+            onClick={handleIngest}
+          >
+            Ingest Trending Content
+          </button>
+          {ingestMessage && <p className="mt-2 text-sm text-center">{ingestMessage}</p>}
+        </div>
+
         <input
           className="w-full p-3 mb-4 rounded bg-gray-800 border border-gray-700 focus:outline-none focus:ring-2 focus:ring-blue-600"
           type="text"


### PR DESCRIPTION
## Summary
- add Pyppeteer ingestion stub and provider routing for Apify, Playwright, or Puppeteer
- support Groq Whisper transcription with ffmpeg audio extraction
- expose provider selection via API models, router, frontend dropdown, and docs

## Testing
- `python -m py_compile backend/services/ingestion.py backend/services/transcription.py backend/models.py backend/routers/ingest.py`
- `pytest`
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68bcee0fd220832b93bece0b0c1a4f64