### PR TITLE
feat: enrich ingestion and generation pipeline

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -8,3 +8,4 @@ OPENAI_API_KEY=your-openai-api-key
 DALL_E_API_KEY=your-dall-e-api-key
 INGESTION_PROVIDER=apify
 GROQ_API_KEY=your-groq-api-key
+PYTESSERACT_PATH=/usr/bin/tesseract

--- a/backend/models.py
+++ b/backend/models.py
@@ -28,6 +28,31 @@ class GenerateResponse(BaseModel):
     )
 
 
+class VideoRecord(BaseModel):
+    """Model representing an analyzed video stored in Supabase."""
+
+    id: Optional[int] = Field(None, description="Supabase ID for the video record")
+    url: Optional[str] = Field(None, description="Source URL of the video")
+    niche: Optional[str] = Field(None, description="Niche associated with the video")
+    provider: Optional[str] = Field(None, description="Scraping provider used")
+    transcript: Optional[str] = Field(None, description="Transcribed audio text")
+    pacing: Optional[float] = Field(
+        None, description="Average shot length in seconds derived from scenedetect/opencv"
+    )
+    visual_style: Optional[str] = Field(
+        None, description="Basic visual style classification such as cinematic or lo-fi"
+    )
+    onscreen_text: Optional[str] = Field(
+        None, description="Detected on-screen text via OCR"
+    )
+    audio_id: Optional[str] = Field(
+        None, description="Identifier for the video's audio track"
+    )
+    trending_audio: bool = Field(
+        False, description="Flag indicating if the audio track is trending"
+    )
+
+
 class IngestRequest(BaseModel):
     """Request model for ingesting trending content data."""
     niches: List[str] = Field(..., description="List of content niches to ingest, e.g., ['tech', 'fitness'].")
@@ -40,9 +65,14 @@ class IngestRequest(BaseModel):
 
 class IngestResponse(BaseModel):
     """Response confirming that an ingest request was processed."""
+
     message: str
     video_ids: List[int] = Field(
         default_factory=list, description="Supabase IDs of stored video records."
+    )
+    videos: List[VideoRecord] = Field(
+        default_factory=list,
+        description="Enriched video records stored in Supabase",
     )
     patterns: List[str] = Field(
         default_factory=list, description="Identified content patterns from ingestion."

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -7,3 +7,10 @@ openai>=1.3.0
 supabase>=2.0.0
 playwright==1.41.2
 pyppeteer==1.0.2
+opencv-python==4.9.0.80
+scenedetect==0.6.2
+moviepy==1.0.3
+librosa==0.10.1
+pytesseract==0.3.10
+ffmpeg-python==0.2.0
+groq>=0.4.2

--- a/frontend/pages/index.tsx
+++ b/frontend/pages/index.tsx
@@ -8,9 +8,19 @@ interface GenerateResponse {
   package_id?: number;
 }
 
+interface VideoRecord {
+  id?: number;
+  url?: string;
+  pacing?: number;
+  visual_style?: string;
+  onscreen_text?: string;
+  trending_audio?: boolean;
+}
+
 interface IngestResponse {
   message: string;
   video_ids: number[];
+  videos: VideoRecord[];
   patterns: string[];
   pattern_ids: number[];
   generated?: GenerateResponse;
@@ -92,6 +102,19 @@ export default function Home() {
           )}
           {ingestData?.video_ids && ingestData.video_ids.length > 0 && (
             <p className="mt-1 text-xs text-center">Stored videos: {ingestData.video_ids.join(', ')}</p>
+          )}
+          {ingestData?.videos && ingestData.videos.length > 0 && (
+            <div className="mt-4 bg-gray-800 p-4 rounded">
+              <h2 className="text-2xl font-semibold mb-2">Video Analysis</h2>
+              <ul className="list-disc list-inside">
+                {ingestData.videos.map((v, idx) => (
+                  <li key={idx} className="mb-2">
+                    <div>Pacing: {v.pacing ?? 'n/a'}s, Style: {v.visual_style ?? 'n/a'}{v.trending_audio ? ' (Trending audio)' : ''}</div>
+                    {v.onscreen_text && <div className="text-xs">Text: {v.onscreen_text}</div>}
+                  </li>
+                ))}
+              </ul>
+            </div>
           )}
           {ingestData?.patterns && ingestData.patterns.length > 0 && (
             <div className="mt-4 bg-gray-800 p-4 rounded">


### PR DESCRIPTION
## Summary
- consolidate backend requirements with audio/visual analysis libraries
- extend ingestion to analyse pacing, style, on-screen text and trending audio
- propagate new video insights into strategy, generation, API and dashboard

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_68bdb3e163d4832bb424ea8efd0e59a9