### PR TITLE
feat: add trending audio and pattern modules

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -9,3 +9,6 @@ DALL_E_API_KEY=your-dall-e-api-key
 INGESTION_PROVIDER=apify
 GROQ_API_KEY=your-groq-api-key
 PYTESSERACT_PATH=/usr/bin/tesseract
+PATTERN_MODEL=gpt-4o-mini
+GENERATION_MODEL=gpt-4o-mini
+TRENDING_AUDIO_LIMIT=10

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ ViralSynth is an autonomous content strategy & generation engine designed to hel
 This repository contains two services:
 
 - `backend/` – a FastAPI application that exposes REST endpoints for ingesting trending content, analyzing strategies and generating content packages.
-- `frontend/` – a Next.js webapp with Tailwind CSS that provides a dashboard for entering prompts and viewing generated scripts, images and notes.
+- `frontend/` – a Next.js webapp with Tailwind CSS that provides a dashboard for entering prompts and viewing generated scripts, images and notes. The dashboard now surfaces trending audio metrics and structured pattern details.
 
 Supporting agent specifications (`agents.md`, `agents_architect.md`, `agents_spec_writer.md`, `agents_project_manager.md`) outline the autonomous agents used to build the system. The `status.md` file tracks outstanding work.
 
@@ -32,9 +32,9 @@ Supporting agent specifications (`agents.md`, `agents_architect.md`, `agents_spe
 
 | Method | Endpoint        | Description                          |
 |-------|-----------------|--------------------------------------|
-| POST  | `/api/ingest`      | Ingest trending content data, analyze pacing, style, text and audio, store videos in Supabase and return pattern and package IDs. |
-| POST  | `/api/strategy`    | Analyze stored videos in Supabase and persist extracted patterns. |
-| POST  | `/api/generate`    | Generate a full content package from stored patterns and save it in Supabase. |
+| POST  | `/api/ingest`      | Ingest trending content data, analyze pacing, style, text and audio, store videos in Supabase and return pattern IDs, trending audio rankings and a sample package. |
+| POST  | `/api/strategy`    | Analyze stored videos in Supabase and persist structured templates (hook, value loop, narrative arc, visual formula, CTA). |
+| POST  | `/api/generate`    | Generate a full content package from stored patterns and trending audio hints and save it in Supabase. |
 
 These endpoints now persist videos, patterns and generated packages to Supabase. LLM and scraping integrations remain rudimentary and should be expanded for production use.
 
@@ -59,9 +59,9 @@ The frontend includes a provider dropdown for ingestion requests and displays st
 
 ### Workflow
 
-1. **Ingestion** – fetch trending videos for a niche, transcribe audio via Groq Whisper, analyse shot pacing with SceneDetect/OpenCV, classify visual style, run OCR for on‑screen text and flag reused audio as trending. Records are stored in Supabase and returned to the client.
-2. **Strategy** – GPT‑4/Claude evaluates the ingested `VideoRecord` objects to derive hooks, core value loops, narrative arcs, visual formulas and CTAs.
-3. **Generation** – using the extracted patterns and trending audio hints, GPT generates a script, DALL‑E storyboard, production notes (including pacing/style guidance) and platform‑specific variations.
+1. **Ingestion** – fetch trending videos for a niche, transcribe audio via Groq Whisper, analyse shot pacing with SceneDetect/OpenCV, classify visual style, run OCR for on‑screen text and aggregate audio usage to rank trending tracks with source links.
+2. **Strategy** – GPT‑4/Claude evaluates the ingested `VideoRecord` objects with simple statistics to derive structured templates (hook, core value loop, narrative arc, visual formula, CTA) which are saved in Supabase.
+3. **Generation** – using the extracted patterns, trending audio, pacing and visual style hints, GPT generates a script, DALL‑E storyboard, production notes and platform‑specific hook/CTA variations.
 
 ### Ingestion Providers
 

--- a/agents_advanced_generation.md
+++ b/agents_advanced_generation.md
@@ -1,0 +1,21 @@
+# agents_advanced_generation.md – Advanced Generation Architect
+
+## Mission
+Synthesize multi‑modal content packages that incorporate trending audio, pacing, visual style and mined patterns, delivering platform‑specific hooks and CTAs.
+
+## Responsibilities
+- Retrieve relevant patterns and trending audio metadata from Supabase.
+- Combine GPT prompts with style/pacing hints to generate scripts, storyboards and production notes.
+- Produce platform variations for hooks and calls to action.
+
+## Inputs
+- User generation requests `{prompt, niche, platform}`.
+- Pattern and audio metadata from other agents.
+
+## Outputs
+- Content package `{script, storyboard[], notes[], variations{platform:{hook, cta}}, audio_id}` stored in Supabase.
+
+## KPIs
+- Engagement rate of generated content compared to baseline.
+- Turnaround time per generation request.
+- Coverage of supported platforms for variations.

--- a/agents_pattern_recognition.md
+++ b/agents_pattern_recognition.md
@@ -1,0 +1,20 @@
+# agents_pattern_recognition.md – Pattern Recognition Specialist
+
+## Mission
+Identify repeatable narrative, visual and engagement patterns from stored videos and turn them into reusable templates.
+
+## Responsibilities
+- Fetch transcripts, pacing, style and text descriptors from Supabase.
+- Use GPT and statistical heuristics to extract structured templates including hook, core value loop, narrative arc, visual formula and CTA.
+- Store extracted patterns back into Supabase for later generation.
+
+## Inputs
+- Video descriptors from ingestion phase.
+
+## Outputs
+- List of pattern records `{hook, core_value_loop, narrative_arc, visual_formula, cta}` with Supabase IDs.
+
+## KPIs
+- Precision of extracted hooks and CTAs in A/B testing.
+- Percentage of patterns successfully persisted.
+- Average time to process a batch of videos.

--- a/agents_trending_audio.md
+++ b/agents_trending_audio.md
@@ -1,0 +1,20 @@
+# agents_trending_audio.md – Trending Audio Analyst
+
+## Mission
+Track and evaluate the popularity of audio tracks across the ViralSynth dataset so content creators can leverage the most effective sounds.
+
+## Responsibilities
+- Aggregate audio identifiers from ingested videos and compute usage counts.
+- Rank audio tracks by frequency and expose top results with source links.
+- Surface audio metadata to other agents for strategy and generation.
+
+## Inputs
+- Video records stored in Supabase including `audio_id` and `url`.
+
+## Outputs
+- Ordered list of trending audio objects `{audio_id, count, url}`.
+
+## KPIs
+- Accuracy of ranking compared to ground‑truth datasets.
+- Latency of aggregation queries.
+- Availability of source links for each trending audio record.

--- a/backend/models.py
+++ b/backend/models.py
@@ -4,27 +4,61 @@ from pydantic import BaseModel, Field
 from typing import Dict, List, Optional
 
 
+class TrendingAudio(BaseModel):
+    """Representation of an audio track ranked by usage."""
+
+    audio_id: str = Field(..., description="Identifier for the audio track")
+    count: int = Field(..., description="Number of videos using this audio")
+    url: Optional[str] = Field(None, description="Source link for the audio")
+
+
+class Pattern(BaseModel):
+    """Structured template extracted from analyzed videos."""
+
+    id: Optional[int] = Field(None, description="Supabase ID of the pattern")
+    hook: str = Field(..., description="Opening hook used to grab attention")
+    core_value_loop: str = Field(..., description="Main value delivery loop")
+    narrative_arc: str = Field(..., description="Narrative arc or storyline")
+    visual_formula: str = Field(..., description="Visual style or formula")
+    cta: str = Field(..., description="Call to action at the end")
+
+
 class GenerateRequest(BaseModel):
     """Request model for generating content packages."""
+
     prompt: str = Field(..., description="User-provided idea or topic for the content.")
     platform: Optional[str] = Field("tiktok", description="Target platform: tiktok, instagram, or youtube.")
     niche: Optional[str] = Field(None, description="Content niche, e.g., tech, fitness, finance.")
     pattern_ids: Optional[List[int]] = Field(
-        None, description="Optional Supabase pattern IDs to condition generation."
+        None, description="Optional Supabase pattern IDs to condition generation.",
     )
+
+
+class PlatformVariation(BaseModel):
+    """Hook and CTA pair tailored to a platform."""
+
+    hook: str
+    cta: str
 
 
 class GenerateResponse(BaseModel):
     """Response model for generated content packages."""
+
     script: str
     storyboard: List[str]
     notes: List[str]
-    variations: Dict[str, str] = Field(
+    variations: Dict[str, PlatformVariation] = Field(
         default_factory=dict,
         description="Platform-specific hook and CTA variations",
     )
+    audio_id: Optional[str] = Field(
+        None, description="Trending audio identifier used for generation",
+    )
+    audio_url: Optional[str] = Field(
+        None, description="Source link for the selected audio",
+    )
     package_id: Optional[int] = Field(
-        None, description="Supabase ID for the stored generated package."
+        None, description="Supabase ID for the stored generated package.",
     )
 
 
@@ -37,26 +71,32 @@ class VideoRecord(BaseModel):
     provider: Optional[str] = Field(None, description="Scraping provider used")
     transcript: Optional[str] = Field(None, description="Transcribed audio text")
     pacing: Optional[float] = Field(
-        None, description="Average shot length in seconds derived from scenedetect/opencv"
+        None, description="Average shot length in seconds derived from scenedetect/opencv",
     )
     visual_style: Optional[str] = Field(
-        None, description="Basic visual style classification such as cinematic or lo-fi"
+        None, description="Basic visual style classification such as cinematic or lo-fi",
     )
     onscreen_text: Optional[str] = Field(
-        None, description="Detected on-screen text via OCR"
+        None, description="Detected on-screen text via OCR",
     )
     audio_id: Optional[str] = Field(
-        None, description="Identifier for the video's audio track"
+        None, description="Identifier for the video's audio track",
+    )
+    audio_url: Optional[str] = Field(
+        None, description="Source link for the video's audio track",
     )
     trending_audio: bool = Field(
-        False, description="Flag indicating if the audio track is trending"
+        False, description="Flag indicating if the audio track is trending",
     )
 
 
 class IngestRequest(BaseModel):
     """Request model for ingesting trending content data."""
+
     niches: List[str] = Field(..., description="List of content niches to ingest, e.g., ['tech', 'fitness'].")
-    top_percentile: float = Field(0.05, description="Top percentile threshold (0-1) for selecting high performing content.")
+    top_percentile: float = Field(
+        0.05, description="Top percentile threshold (0-1) for selecting high performing content.",
+    )
     provider: Optional[str] = Field(
         None,
         description="Optional scraping provider: apify, playwright, or puppeteer.",
@@ -68,17 +108,20 @@ class IngestResponse(BaseModel):
 
     message: str
     video_ids: List[int] = Field(
-        default_factory=list, description="Supabase IDs of stored video records."
+        default_factory=list, description="Supabase IDs of stored video records.",
     )
     videos: List[VideoRecord] = Field(
         default_factory=list,
         description="Enriched video records stored in Supabase",
     )
-    patterns: List[str] = Field(
-        default_factory=list, description="Identified content patterns from ingestion."
+    patterns: List[Pattern] = Field(
+        default_factory=list, description="Identified content patterns from ingestion.",
     )
     pattern_ids: List[int] = Field(
-        default_factory=list, description="Supabase IDs of stored patterns."
+        default_factory=list, description="Supabase IDs of stored patterns.",
+    )
+    trending_audios: List[TrendingAudio] = Field(
+        default_factory=list, description="Ranked trending audio tracks across dataset",
     )
     generated: Optional[GenerateResponse] = Field(
         None,
@@ -88,16 +131,17 @@ class IngestResponse(BaseModel):
 
 class StrategyRequest(BaseModel):
     """Request model for analyzing content patterns."""
+
     niches: List[str]
     video_ids: Optional[List[int]] = Field(
-        None, description="Specific Supabase video IDs to analyze."
+        None, description="Specific Supabase video IDs to analyze.",
     )
 
 
 class StrategyResponse(BaseModel):
-    patterns: List[str] = Field(
-        default_factory=list, description="Identified successful content patterns."
+    patterns: List[Pattern] = Field(
+        default_factory=list, description="Identified successful content patterns.",
     )
     pattern_ids: List[int] = Field(
-        default_factory=list, description="Supabase IDs for stored patterns."
+        default_factory=list, description="Supabase IDs for stored patterns.",
     )

--- a/backend/routers/ingest.py
+++ b/backend/routers/ingest.py
@@ -9,7 +9,7 @@ from ..models import (
     StrategyRequest,
     GenerateRequest,
 )
-from ..services.ingestion import ingest_niche
+from ..services.ingestion import ingest_niche, get_trending_audio
 from ..services.strategy import derive_patterns
 from ..services.generation import generate_package
 
@@ -37,6 +37,8 @@ async def ingest_trending_content(request: IngestRequest) -> IngestResponse:
         video_records.extend(records)
     video_ids = [v.id for v in video_records if v.id]
 
+    trending_audios = await get_trending_audio()
+
     # After ingestion, analyze patterns across the stored videos.
     strategy_resp = await derive_patterns(
         StrategyRequest(niches=request.niches, video_ids=video_ids)
@@ -62,5 +64,6 @@ async def ingest_trending_content(request: IngestRequest) -> IngestResponse:
         videos=video_records,
         patterns=strategy_resp.patterns,
         pattern_ids=strategy_resp.pattern_ids,
+        trending_audios=trending_audios,
         generated=generate_resp,
     )

--- a/frontend/pages/index.tsx
+++ b/frontend/pages/index.tsx
@@ -1,10 +1,17 @@
 import { useState } from 'react';
 
+interface PlatformVariation {
+  hook: string;
+  cta: string;
+}
+
 interface GenerateResponse {
   script: string;
   storyboard: string[];
   notes: string[];
-  variations: Record<string, string>;
+  variations: Record<string, PlatformVariation>;
+  audio_id?: string;
+  audio_url?: string;
   package_id?: number;
 }
 
@@ -14,15 +21,33 @@ interface VideoRecord {
   pacing?: number;
   visual_style?: string;
   onscreen_text?: string;
+  audio_id?: string;
+  audio_url?: string;
   trending_audio?: boolean;
+}
+
+interface Pattern {
+  id?: number;
+  hook: string;
+  core_value_loop: string;
+  narrative_arc: string;
+  visual_formula: string;
+  cta: string;
+}
+
+interface TrendingAudio {
+  audio_id: string;
+  count: number;
+  url?: string;
 }
 
 interface IngestResponse {
   message: string;
   video_ids: number[];
   videos: VideoRecord[];
-  patterns: string[];
+  patterns: Pattern[];
   pattern_ids: number[];
+  trending_audios: TrendingAudio[];
   generated?: GenerateResponse;
 }
 
@@ -103,13 +128,30 @@ export default function Home() {
           {ingestData?.video_ids && ingestData.video_ids.length > 0 && (
             <p className="mt-1 text-xs text-center">Stored videos: {ingestData.video_ids.join(', ')}</p>
           )}
+          {ingestData?.trending_audios && ingestData.trending_audios.length > 0 && (
+            <div className="mt-2 text-xs text-center">
+              Top audio:
+              {ingestData.trending_audios.map((a, idx) => (
+                <span key={a.audio_id} className="block">
+                  {idx + 1}. <a href={a.url} className="underline" target="_blank" rel="noreferrer">{a.audio_id}</a> ({a.count})
+                </span>
+              ))}
+            </div>
+          )}
           {ingestData?.videos && ingestData.videos.length > 0 && (
             <div className="mt-4 bg-gray-800 p-4 rounded">
               <h2 className="text-2xl font-semibold mb-2">Video Analysis</h2>
               <ul className="list-disc list-inside">
                 {ingestData.videos.map((v, idx) => (
                   <li key={idx} className="mb-2">
-                    <div>Pacing: {v.pacing ?? 'n/a'}s, Style: {v.visual_style ?? 'n/a'}{v.trending_audio ? ' (Trending audio)' : ''}</div>
+                    <div>
+                      Pacing: {v.pacing ?? 'n/a'}s, Style: {v.visual_style ?? 'n/a'}{v.trending_audio ? ' (Trending audio)' : ''}
+                    </div>
+                    {v.audio_id && (
+                      <div className="text-xs">
+                        Audio: <a href={v.audio_url} className="underline" target="_blank" rel="noreferrer">{v.audio_id}</a>
+                      </div>
+                    )}
                     {v.onscreen_text && <div className="text-xs">Text: {v.onscreen_text}</div>}
                   </li>
                 ))}
@@ -119,11 +161,18 @@ export default function Home() {
           {ingestData?.patterns && ingestData.patterns.length > 0 && (
             <div className="mt-4 bg-gray-800 p-4 rounded">
               <h2 className="text-2xl font-semibold mb-2">Strategy Results</h2>
-              <ul className="list-disc list-inside">
-                {ingestData.patterns.map((pattern, idx) => (
-                  <li key={idx}>{pattern}</li>
-                ))}
-              </ul>
+              {ingestData.patterns.map((p, idx) => (
+                <div key={idx} className="mb-3">
+                  <div className="font-semibold">Pattern {idx + 1}</div>
+                  <ul className="list-disc list-inside text-sm">
+                    <li>Hook: {p.hook}</li>
+                    <li>Value Loop: {p.core_value_loop}</li>
+                    <li>Narrative: {p.narrative_arc}</li>
+                    <li>Visual: {p.visual_formula}</li>
+                    <li>CTA: {p.cta}</li>
+                  </ul>
+                </div>
+              ))}
               {ingestData.pattern_ids && ingestData.pattern_ids.length > 0 && (
                 <p className="text-xs mt-2">Pattern IDs: {ingestData.pattern_ids.join(', ')}</p>
               )}
@@ -150,9 +199,9 @@ export default function Home() {
                   <h2 className="text-2xl font-semibold mb-2">Platform Variations</h2>
                   <ul className="list-disc list-inside">
                     {Object.entries(ingestData.generated.variations).map(
-                      ([platform, text]) => (
+                      ([platform, pv]) => (
                         <li key={platform}>
-                          <strong>{platform}:</strong> {text}
+                          <strong>{platform}:</strong> Hook - {pv.hook}; CTA - {pv.cta}
                         </li>
                       )
                     )}
@@ -200,9 +249,9 @@ export default function Home() {
               <div>
                 <h2 className="text-2xl font-semibold mb-2">Platform Variations</h2>
                 <ul className="list-disc list-inside">
-                  {Object.entries(response.variations).map(([platform, text]) => (
+                  {Object.entries(response.variations).map(([platform, pv]) => (
                     <li key={platform}>
-                      <strong>{platform}:</strong> {text}
+                      <strong>{platform}:</strong> Hook - {pv.hook}; CTA - {pv.cta}
                     </li>
                   ))}
                 </ul>

--- a/status.md
+++ b/status.md
@@ -26,3 +26,6 @@ This file tracks the remaining work required to bring the ViralSynth platform to
 - Integrated ingestion providers (Apify, Playwright, Puppeteer) with strategy and generation placeholders.
 - Frontend now offers provider selection, displays strategy patterns and renders generated scripts, storyboard images and notes.
 - Supabase persistence added for ingested videos, extracted patterns and generated packages; dashboard surfaces stored IDs.
+- Trending audio analyst aggregates audio usage with source links and surfaces rankings in the dashboard.
+- Pattern recognition module stores structured templates (hook, value loop, narrative arc, visual formula, CTA).
+- Generation module uses trending audio, pacing and visual style hints to produce platform-specific hook and CTA variations.


### PR DESCRIPTION
## Summary
- add agent specs for trending audio, pattern recognition, and advanced generation
- compute and expose trending audio rankings with source links
- extract structured content patterns and generate platform-specific hook/CTA variations
- expand dashboard to display audio metrics and pattern details

## Testing
- `python -m pytest`
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68be7770fe14832b9adf0a65f06e4394