### PR TITLE
feat: add pattern mining service and pattern stats API

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Supporting agent specifications (`agents.md`, `agents_architect.md`, `agents_spe
 | POST  | `/api/strategy`    | Analyze stored videos in Supabase and persist structured templates (hook, value loop, narrative arc, visual formula, CTA). |
 | POST  | `/api/generate`    | Generate a full content package from stored patterns and trending audio hints and save it in Supabase. |
 | GET   | `/api/audio/trending` | Retrieve top trending audio clips with usage counts and engagement. |
-| GET   | `/api/patterns`       | Fetch stored patterns ordered by prevalence for a given niche. |
+| GET   | `/api/patterns`       | Fetch stored patterns with prevalence and engagement stats for a given niche. |
 
 These endpoints now persist videos, patterns and generated packages to Supabase. LLM and scraping integrations remain rudimentary and should be expanded for production use.
 
@@ -62,7 +62,7 @@ The frontend includes a provider dropdown for ingestion requests and displays st
 ### Workflow
 
 1. **Ingestion** – fetch trending videos for a niche, transcribe audio via Groq Whisper, analyse shot pacing with SceneDetect/OpenCV, classify visual style, run OCR for on‑screen text and aggregate audio usage to rank trending tracks with source links.
-2. **Strategy** – GPT‑4/Claude evaluates the ingested `VideoRecord` objects with simple statistics to derive structured templates (hook, core value loop, narrative arc, visual formula, CTA) which are saved in Supabase.
+2. **Strategy** – video descriptors are mined to derive structured templates (hook, core value loop, narrative arc, visual formula, CTA) and aggregated into pattern stats (prevalence and average engagement) which are saved in Supabase.
 3. **Generation** – using the extracted patterns, trending audio, pacing and visual style hints, GPT generates a script, DALL‑E storyboard, production notes and platform‑specific hook/CTA variations.
 
 ### Ingestion Providers

--- a/backend/main.py
+++ b/backend/main.py
@@ -3,7 +3,7 @@
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 
-from routers import ingest, strategy, generate, audio, patterns
+from .routers import ingest, strategy, generate, audio, patterns
 
 app = FastAPI(title="ViralSynth API")
 

--- a/backend/migrations/0002_add_pattern_stats.sql
+++ b/backend/migrations/0002_add_pattern_stats.sql
@@ -1,0 +1,5 @@
+-- Migration: ensure patterns table has niche and stats columns
+ALTER TABLE IF EXISTS patterns
+    ADD COLUMN IF NOT EXISTS niche text,
+    ADD COLUMN IF NOT EXISTS prevalence double precision,
+    ADD COLUMN IF NOT EXISTS engagement_score double precision;

--- a/backend/models.py
+++ b/backend/models.py
@@ -21,6 +21,9 @@ class Pattern(BaseModel):
     """Structured template extracted from analyzed videos."""
 
     id: Optional[int] = Field(None, description="Supabase ID of the pattern")
+    niche: Optional[str] = Field(
+        None, description="Content niche where the pattern was observed"
+    )
     hook: str = Field(..., description="Opening hook used to grab attention")
     core_value_loop: str = Field(..., description="Main value delivery loop")
     narrative_arc: str = Field(..., description="Narrative arc or storyline")

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,6 +1,6 @@
 fastapi==0.110.0
 uvicorn[standard]==0.23.2
-pydantic==1.10.12
+pydantic>=2.0.0
 python-multipart==0.0.7
 httpx==0.26.0
 openai>=1.3.0
@@ -14,3 +14,4 @@ librosa==0.10.1
 pytesseract==0.3.10
 ffmpeg-python==0.2.0
 groq>=0.4.2
+pytest==8.2.2

--- a/backend/services/pattern_miner.py
+++ b/backend/services/pattern_miner.py
@@ -1,0 +1,119 @@
+"""Pattern mining utilities for ViralSynth.
+
+This service extracts hooks, core value loops, narrative arcs,
+visual formulas and CTAs from transcripts and shot graphs and computes
+prevalence/engagement statistics per niche.
+"""
+
+from collections import defaultdict
+from typing import Dict, List, Tuple
+
+from ..models import Pattern
+
+
+def _split_sentences(text: str) -> List[str]:
+    """Naive sentence splitter used for hook/core/cta extraction."""
+    if not text:
+        return []
+    return [s.strip() for s in text.replace("\n", " ").split(".") if s.strip()]
+
+
+def _extract_components(record: Dict) -> Tuple[str, str, str, str, str]:
+    """Extract pattern components from a single video record."""
+    transcript = record.get("transcript", "")
+    visual_style = record.get("visual_style", "") or "unspecified"
+    sentences = _split_sentences(transcript)
+
+    hook = sentences[0] if sentences else ""
+    cta = sentences[-1] if len(sentences) > 1 else ""
+    core = " ".join(sentences[1:-1]) if len(sentences) > 2 else ""
+
+    narrative_arc = "informational"
+    if any(word in transcript.lower() for word in ["story", "journey", "once"]):
+        narrative_arc = "story"
+
+    visual_formula = visual_style
+
+    return hook, core, narrative_arc, visual_formula, cta
+
+
+def mine_patterns_from_records(records: List[Dict], niche: str) -> List[Pattern]:
+    """Group video records into unique patterns and compute statistics."""
+    total = len(records)
+    groups: Dict[Tuple[str, str, str, str, str], Dict[str, float]] = defaultdict(
+        lambda: {"count": 0, "engagement": 0.0}
+    )
+
+    for rec in records:
+        hook, core, arc, visual, cta = _extract_components(rec)
+        key = (hook, core, arc, visual, cta)
+        engagement = float((rec.get("likes") or 0) + (rec.get("comments") or 0))
+        groups[key]["count"] += 1
+        groups[key]["engagement"] += engagement
+
+    patterns: List[Pattern] = []
+    for key, stats in groups.items():
+        count = stats["count"]
+        engagement_avg = stats["engagement"] / count if count else 0.0
+        prevalence = count / total if total else 0.0
+        patterns.append(
+            Pattern(
+                hook=key[0],
+                core_value_loop=key[1],
+                narrative_arc=key[2],
+                visual_formula=key[3],
+                cta=key[4],
+                prevalence=prevalence,
+                engagement_score=engagement_avg,
+                niche=niche,
+            )
+        )
+
+    return patterns
+
+
+async def mine_and_store_patterns(niche: str) -> List[Pattern]:
+    """Fetch video records for a niche, mine patterns and persist them."""
+    from .supabase import get_supabase_client
+
+    supabase = get_supabase_client()
+    records: List[Dict] = []
+    if supabase:
+        try:
+            resp = (
+                supabase.table("videos")
+                .select(
+                    "transcript,visual_style,onscreen_text,likes,comments"
+                )
+                .eq("niche", niche)
+                .execute()
+            )
+            records = resp.data or []
+        except Exception:
+            records = []
+
+    patterns = mine_patterns_from_records(records, niche)
+
+    if supabase and patterns:
+        rows = [
+            {
+                "niche": p.niche,
+                "hook": p.hook,
+                "core_value_loop": p.core_value_loop,
+                "narrative_arc": p.narrative_arc,
+                "visual_formula": p.visual_formula,
+                "cta": p.cta,
+                "prevalence": p.prevalence,
+                "engagement_score": p.engagement_score,
+            }
+            for p in patterns
+        ]
+        try:
+            resp = supabase.table("patterns").insert(rows).execute()
+            if resp.data:
+                for pat, row in zip(patterns, resp.data):
+                    pat.id = row.get("id")
+        except Exception:
+            pass
+
+    return patterns

--- a/backend/services/strategy.py
+++ b/backend/services/strategy.py
@@ -1,17 +1,15 @@
 """Service functions for analyzing content patterns from Supabase."""
 
 import os
-import json
 from typing import List, Optional
-from openai import AsyncOpenAI
 
 from ..models import Pattern, StrategyRequest, StrategyResponse
 from .supabase import get_supabase_client
-from .ingestion import get_trending_audio
+from .pattern_miner import mine_patterns_from_records
 
 
 async def derive_patterns(request: StrategyRequest) -> StrategyResponse:
-    """Fetch transcripts/descriptors from Supabase and extract patterns via GPT."""
+    """Fetch video descriptors from Supabase and mine recurring patterns."""
     supabase = get_supabase_client()
     videos = []
     if supabase:
@@ -29,56 +27,14 @@ async def derive_patterns(request: StrategyRequest) -> StrategyResponse:
         except Exception:
             videos = []
 
-    transcripts = [v.get("transcript", "") for v in videos if v.get("transcript")]
-    pacing = [v.get("pacing") for v in videos if v.get("pacing")]
-    styles = [v.get("visual_style") for v in videos if v.get("visual_style")]
-    texts = [v.get("onscreen_text") for v in videos if v.get("onscreen_text")]
-    audios = [v.get("trending_audio") for v in videos]
-    engagements = [
-        (v.get("likes") or 0) + (v.get("comments") or 0) for v in videos
-    ]
-    avg_engagement = sum(engagements) / len(engagements) if engagements else 0.0
-    prevalence = float(len(videos)) if videos else 0.0
-
-    prompt = (
-        "From the following video data derive recurring patterns. Return JSON with a list of objects each containing"
-        " keys: hook, core_value_loop, narrative_arc, visual_formula, cta."\
-        f"\nTranscripts: {transcripts}"\
-        f"\nPacing: {pacing}"\
-        f"\nVisual Style: {styles}"\
-        f"\nOn-screen Text: {texts}"\
-    )
-
-    patterns: List[Pattern] = []
-    try:
-        client = AsyncOpenAI(api_key=os.environ.get("OPENAI_API_KEY"))
-        completion = await client.chat.completions.create(
-            model=os.environ.get("PATTERN_MODEL", "gpt-4o-mini"),
-            messages=[{"role": "user", "content": prompt}],
-        )
-        data = json.loads(completion.choices[0].message.content)
-        for p in data.get("patterns", []):
-            patterns.append(Pattern(**p))
-    except Exception:
-        patterns = [
-            Pattern(
-                hook="Ask a bold question over trending audio",
-                core_value_loop="Provide three rapid tips",
-                narrative_arc="Problem-solution reveal",
-                visual_formula="Lo-fi selfie clips with captions",
-                cta="Follow for more hacks",
-            )
-        ]
-
-    for p in patterns:
-        p.prevalence = prevalence
-        p.engagement_score = avg_engagement
+    niche = request.niches[0] if request.niches else "general"
+    patterns: List[Pattern] = mine_patterns_from_records(videos, niche)
 
     pattern_ids: List[int] = []
     if supabase and patterns:
         rows = [
             {
-                "niche": request.niches[0] if request.niches else None,
+                "niche": p.niche,
                 "hook": p.hook,
                 "core_value_loop": p.core_value_loop,
                 "narrative_arc": p.narrative_arc,
@@ -98,7 +54,8 @@ async def derive_patterns(request: StrategyRequest) -> StrategyResponse:
         except Exception:
             pass
 
-    niche = request.niches[0] if request.niches else None
+    from .ingestion import get_trending_audio
+
     trending_audios = await get_trending_audio(niche=niche)
     return StrategyResponse(
         patterns=patterns, pattern_ids=pattern_ids, trending_audios=trending_audios
@@ -113,7 +70,7 @@ async def fetch_patterns(niche: Optional[str] = None, limit: int = 10) -> List[P
         return []
     try:
         query = supabase.table("patterns").select(
-            "id,hook,core_value_loop,narrative_arc,visual_formula,cta,prevalence,engagement_score"
+            "id,niche,hook,core_value_loop,narrative_arc,visual_formula,cta,prevalence,engagement_score"
         )
         if niche:
             query = query.eq("niche", niche)

--- a/backend/tests/test_pattern_miner.py
+++ b/backend/tests/test_pattern_miner.py
@@ -1,0 +1,42 @@
+import math
+
+from backend.services.pattern_miner import mine_patterns_from_records
+
+
+def test_mine_patterns_from_records_groups_and_stats():
+    records = [
+        {
+            "transcript": "Try this growth hack. Step one post daily. Follow for more tips.",
+            "visual_style": "lofi",
+            "likes": 10,
+            "comments": 5,
+        },
+        {
+            "transcript": "Try this growth hack. Step one post daily. Follow for more tips.",
+            "visual_style": "lofi",
+            "likes": 20,
+            "comments": 10,
+        },
+        {
+            "transcript": "Here is my story. I failed once. Now I teach others. Subscribe for more.",
+            "visual_style": "cinematic",
+            "likes": 5,
+            "comments": 0,
+        },
+    ]
+
+    patterns = mine_patterns_from_records(records, niche="marketing")
+    assert len(patterns) == 2
+
+    # Find first pattern with hook 'Try this growth hack'
+    p1 = next(p for p in patterns if p.hook == "Try this growth hack")
+    assert math.isclose(p1.prevalence, 2 / 3, rel_tol=1e-5)
+    assert math.isclose(p1.engagement_score, 22.5, rel_tol=1e-5)
+    assert p1.narrative_arc == "informational"
+    assert p1.visual_formula == "lofi"
+
+    # Second pattern stats
+    p2 = next(p for p in patterns if p.hook == "Here is my story")
+    assert math.isclose(p2.prevalence, 1 / 3, rel_tol=1e-5)
+    assert math.isclose(p2.engagement_score, 5.0, rel_tol=1e-5)
+    assert p2.narrative_arc == "story"

--- a/backend/tests/test_patterns_api.py
+++ b/backend/tests/test_patterns_api.py
@@ -1,0 +1,43 @@
+from fastapi.testclient import TestClient
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+import sys
+from types import SimpleNamespace
+
+from backend.models import Pattern
+
+
+def test_list_patterns_endpoint(monkeypatch):
+    sys.modules.setdefault(
+        "supabase", SimpleNamespace(create_client=lambda *a, **k: None, Client=object)
+    )
+    from backend.routers import patterns as patterns_router
+
+    app = FastAPI()
+    app.include_router(patterns_router.router)
+    async def fake_fetch_patterns(niche=None, limit=10):
+        return [
+            Pattern(
+                id=1,
+                niche="tech",
+                hook="Bold claim",
+                core_value_loop="Explain three tips",
+                narrative_arc="informational",
+                visual_formula="lofi",
+                cta="Follow",
+                prevalence=0.5,
+                engagement_score=100.0,
+            )
+        ]
+
+    monkeypatch.setattr(
+        "backend.routers.patterns.fetch_patterns", fake_fetch_patterns
+    )
+    client = TestClient(app)
+    resp = client.get("/api/patterns?niche=tech")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data[0]["hook"] == "Bold claim"
+    assert data[0]["prevalence"] == 0.5
+    assert data[0]["engagement_score"] == 100.0


### PR DESCRIPTION
## Summary
- add pattern_miner service to extract hooks, value loops, arcs, visuals, and CTAs then compute prevalence & engagement
- persist mined patterns with niche info and expose `/api/patterns` endpoint returning stats
- include migration, tests, and updated docs for pattern mining

## Testing
- `PYTHONPATH=. pytest backend/tests/test_pattern_miner.py backend/tests/test_patterns_api.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68c0cf427008832bb56a8b8455844b5f